### PR TITLE
support for user and organisations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,6 @@ typings/
 
 # TernJS port file
 .tern-port
+
+# idea project files
+.idea

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ As a result, for this action to work, the token must be associated to a user who
 
 ### organization
 
-**Required** Name of the organisation owning the container package.
+Name of the organization owning the container package. (if empty, the packages of the authenticated user are considered)
 
 ### container
 

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,10 @@ inputs:
     required: true
   organization:
     description: 'Organisation to which the container belongs'
-    required: true
+    required: false
+  user:
+    description: 'User to which the container belongs'
+    required: false
   container:
     description: 'Name of the container to prune'
     required: true

--- a/index.js
+++ b/index.js
@@ -45,9 +45,23 @@ const listOrgContainerVersions = (octokit) => (organization, container) => (page
   state: 'active',
 });
 
+const listUserContainerVersions = (octokit) => (container) => (pageSize, page = 1) => octokit.rest.packages.getAllPackageVersionsForPackageOwnedByAuthenticatedUser({
+  package_type: 'container',
+  package_name: container,
+  page,
+  per_page: pageSize,
+  state: 'active',
+});
+
 const deleteOrgContainerVersion = (octokit) => (organization, container) => (version) => octokit.rest.packages.deletePackageVersionForOrg({
   package_type: 'container',
   org: organization,
+  package_name: container,
+  package_version_id: version.id,
+});
+
+const deleteUserContainerVersion = (octokit) => (container) => (version) => octokit.rest.packages.deletePackageVersionForAuthenticatedUser({
+  package_type: 'container',
   package_name: container,
   package_version_id: version.id,
 });
@@ -91,9 +105,16 @@ const run = async () => {
 
     const octokit = github.getOctokit(token);
 
-    const listVersions = listOrgContainerVersions(octokit)(organization, container);
+    let listVersions
+    let pruneVersion
+    if (organization.length !== 0) {
+      listVersions = listOrgContainerVersions(octokit)(organization, container);
+      pruneVersion = dryRun ? dryRunDelete : deleteOrgContainerVersion(octokit)(organization, container);
+    } else {
+      listVersions = listUserContainerVersions(octokit)(container);
+      pruneVersion = dryRun ? dryRunDelete : deleteUserContainerVersion(octokit)(container);
+    }
     const filterVersion = versionFilter({olderThan, untagged, tagRegex});
-    const pruneVersion = dryRun ? dryRunDelete : deleteOrgContainerVersion(octokit)(organization, container);
 
     const pruningList = await getPruningList(listVersions, filterVersion)(keepLast);
 


### PR DESCRIPTION
This PR add support for user owned containers to this nice action.

organization is now optional as well as user.
only one of them can be defined as parameter otherwise the action fails.

fixes: https://github.com/vlaurin/action-ghcr-prune/issues/2