### PR TITLE
Fix action main to use packaged distributable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Clear node modules
+        run: rm -rf node_modules/
+
       - name: Should prune untagged versions
         uses: ./ # Itself
         id: test_prune_untagged

--- a/action.yml
+++ b/action.yml
@@ -52,4 +52,4 @@ output:
     description: 'Count of container versions that were pruned'
 runs:
   using: 'node16'
-  main: 'index.js'
+  main: 'dist/index.js'


### PR DESCRIPTION
Fixes #58 

This ensures that the action solely relies on the minimised distributable and not on elements from node_modules/ directory which is not checked in.