### PR TITLE
Normalise inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,96 @@ jobs:
       - name: Clear node modules
         run: rm -rf node_modules/
 
+      - name: (Backward compatibility) Should prune untagged versions
+        uses: ./ # Itself
+        id: legacy_test_prune_untagged
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          user: vlaurin
+          container: test-action-ghcr-prune
+          dry-run: true
+          untagged: true
+          keep-last: 1
+
+      - name: (Backward compatibility) Expect 2 untagged versions to be pruned
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const actualCount = ${{ steps.legacy_test_prune_untagged.outputs.count }};
+            const expectedCount = 2;
+
+            if (actualCount !== expectedCount) {
+              core.setFailed(`Expected ${expectedCount} versions to be pruned but was: ${actualCount}`)
+            }
+
+            const actualPruned = '${{ steps.legacy_test_prune_untagged.outputs.prunedVersionIds }}';
+            const expectedPruned = '[15452193,15452086]';
+
+            if (actualPruned !== expectedPruned) {
+              core.setFailed(`Expected ${expectedPruned} to be pruned but was: ${actualPruned}`)
+            }
+
+      - name: (Backward compatibility) Should prune tagged versions without exclusions
+        uses: ./ # Itself
+        id: legacy_test_prune_tagged
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          user: vlaurin
+          container: test-action-ghcr-prune
+          dry-run: true
+          tag-regex: ^pr-
+          keep-tags: |
+            pr-demo
+
+      - name: (Backward compatibility) Expect 3 tagged versions to be pruned
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const actualCount = ${{ steps.legacy_test_prune_tagged.outputs.count }};
+            const expectedCount = 3;
+
+            if (actualCount !== expectedCount) {
+              core.setFailed(`Expected ${expectedCount} versions to be pruned but was: ${actualCount}`)
+            }
+
+            const actualPruned = '${{ steps.legacy_test_prune_tagged.outputs.prunedVersionIds }}';
+            const expectedPruned = '[15452486,15452460,15452388]';
+
+            if (actualPruned !== expectedPruned) {
+              core.setFailed(`Expected ${expectedPruned} to be pruned but was: ${actualPruned}`)
+            }
+
+      - name: (Backward compatibility) Should prune tagged versions without RegEx exclusions
+        uses: ./ # Itself
+        id: legacy_test_prune_tagged_keep_tags_regexes
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          user: vlaurin
+          container: test-action-ghcr-prune
+          dry-run: true
+          tag-regex: ^pr-
+          keep-tags-regexes: |
+            ^pr-[a-z]+
+            ^pr-\d\d2
+
+      - name: (Backward compatibility) Expect 2 tagged versions to be pruned
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const actualCount = ${{ steps.legacy_test_prune_tagged_keep_tags_regexes.outputs.count }};
+            const expectedCount = 2;
+
+            if (actualCount !== expectedCount) {
+              core.setFailed(`Expected ${expectedCount} versions to be pruned but was: ${actualCount}`)
+            }
+
+            const actualPruned = '${{ steps.legacy_test_prune_tagged_keep_tags_regexes.outputs.prunedVersionIds }}';
+            const expectedPruned = '[15452486,15452388]';
+
+            if (actualPruned !== expectedPruned) {
+              core.setFailed(`Expected ${expectedPruned} to be pruned but was: ${actualPruned}`)
+            }
+
       - name: Should prune untagged versions
         uses: ./ # Itself
         id: test_prune_untagged
@@ -42,7 +132,7 @@ jobs:
           user: vlaurin
           container: test-action-ghcr-prune
           dry-run: true
-          untagged: true
+          prune-untagged: true
           keep-last: 1
 
       - name: Expect 2 untagged versions to be pruned
@@ -71,7 +161,7 @@ jobs:
           user: vlaurin
           container: test-action-ghcr-prune
           dry-run: true
-          tag-regex: ^pr-
+          prune-tags-regexes: ^pr-
           keep-tags: |
             pr-demo
 
@@ -101,7 +191,7 @@ jobs:
           user: vlaurin
           container: test-action-ghcr-prune
           dry-run: true
-          tag-regex: ^pr-
+          prune-tags-regexes: ^pr-
           keep-tags-regexes: |
             ^pr-[a-z]+
             ^pr-\d\d2
@@ -119,6 +209,37 @@ jobs:
 
             const actualPruned = '${{ steps.test_prune_tagged_keep_tags_regexes.outputs.prunedVersionIds }}';
             const expectedPruned = '[15452486,15452388]';
+
+            if (actualPruned !== expectedPruned) {
+              core.setFailed(`Expected ${expectedPruned} to be pruned but was: ${actualPruned}`)
+            }
+
+      - name: Should prune tagged versions from many regexes
+        uses: ./ # Itself
+        id: test_prune_many_tags_regexes
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          user: vlaurin
+          container: test-action-ghcr-prune
+          dry-run: true
+          prune-tags-regexes: |
+            ^pr-[a-z]+$
+            ^pr-\d{3}$
+          keep-tags-regexes: 2$
+
+      - name: Expect 3 tagged versions to be pruned
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const actualCount = ${{ steps.test_prune_many_tags_regexes.outputs.count }};
+            const expectedCount = 3;
+
+            if (actualCount !== expectedCount) {
+              core.setFailed(`Expected ${expectedCount} versions to be pruned but was: ${actualCount}`)
+            }
+
+            const actualPruned = '${{ steps.test_prune_many_tags_regexes.outputs.prunedVersionIds }}';
+            const expectedPruned = '[15452525,15452486,15452388]';
 
             if (actualPruned !== expectedPruned) {
               core.setFailed(`Expected ${expectedPruned} to be pruned but was: ${actualPruned}`)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # action-ghcr-prune
+
 GitHub Action to prune/delete container versions from GitHub Container Registry (ghcr.io).
 
 ## ⚠️ Word of caution
@@ -11,6 +12,7 @@ This is especially true when the [`prune-tags-regexes` input](#prune-tags-regexe
 
 ## Quick start
 
+Pruning all untagged versions older than 7 days, except the 2 most recent:
 ```yml
 steps:
   - name: Prune
@@ -24,6 +26,8 @@ steps:
       keep-last: 2
       prune-untagged: true
 ```
+
+For more pruning strategies, [see filters](#Filters).
 
 ## Permissions
 
@@ -67,26 +71,57 @@ If neither are provided, then the packages of the authenticated user (cf. `token
 
 As this action is destructive, it's recommended to test any changes to the configuration of the action with a dry-run to ensure the expected versions are matched for pruning.
 
-### keep-last
+### :mag: Filters
+
+This action supports 2 types of filters:
+
+- Exclusion filters, prefixed with `keep-`, exclude versions from pruning, preventing them from being deleted.
+- Inclusion filters, prefixed with `prune-`, select the versions to prune.
+
+**Exclusion filters always take precedence over inclusion filters.**
+This means that if a version of a container is matched by both an exclusion and an inclusion filter, the exclusion will take priority and the version will not be pruned.
+
+Versions that are not matched by any filter are preserved.
+
+#### keep-last
 
 **Optional** Count of most recent, matching containers to exclude from pruning. Defaults to `0` which means that all matching containers are pruned.
 
-### keep-tags
+#### keep-tags
 
 **Optional** List of tags to exclude from pruning, one per line.
 Any version with at least one matching tag will be excluded.
 Matching is exact and case-sensitive.
 
-### keep-tags-regexes
+#### keep-tags-regexes
 
 **Optional** List of regular expressions for tags to exclude from pruning, one per line.
 Each expression will be evaluated against all tags of a version. Any version with at least one tag matching the expression will be excluded from pruning.
 
-### keep-younger-than
+For example, pruning all versions with tags starting with either `pr-` or `test-`, except the ones ending with numbers 42 or 1337:
+
+```yml
+steps:
+  - name: Prune
+    uses: vlaurin/action-ghcr-prune@main
+    with:
+      token: ${{ secrets.YOUR_TOKEN }}
+      organization: your-org
+      container: your-container
+      dry-run: true # Dry-run first, then change to `false`
+      keep-tags-regexes: |
+        42$
+        1337$
+      prune-tags-regexes: |
+        ^pr-
+        ^test-
+```
+
+#### keep-younger-than
 
 **Optional** Minimum age in days a version must have to qualify for pruning. All versions below that age at time of execution are excluded from pruning. Defaults to `0` which means no versions will be excluded from pruning.
 
-### prune-tags-regexes
+#### prune-tags-regexes
 
 **Optional** List of regular expressions for tags to prune, one per line.
 Each expression will be evaluated against all tags of a version.
@@ -95,7 +130,23 @@ Disabled by default (ie. no versions pruned based on tags).
 
 :warning: **Please note:** Extra care should be taken when using `prune-tags-regexes`, please make sure you've read the [Word of caution](#word-of-caution)
 
-### prune-untagged
+
+For example, pruning all versions with tags starting with either `pr-` or `test-`:
+```yml
+steps:
+  - name: Prune
+    uses: vlaurin/action-ghcr-prune@main
+    with:
+      token: ${{ secrets.YOUR_TOKEN }}
+      organization: your-org
+      container: your-container
+      dry-run: true # Dry-run first, then change to `false`
+      prune-tags-regexes: |
+        ^pr-
+        ^test-
+```
+
+#### prune-untagged
 
 **Optional** Boolean controlling whether untagged versions should be pruned (`true`) or not (`false`). Defaults to `false`.
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ GitHub Action to prune/delete container versions from GitHub Container Registry 
 
 ## ⚠️ Word of caution
 
-By default, both `untagged` and `tag-regex` inputs are disabled and as result no versions will be matched for pruning. Either or both inputs must be explicitly configured for versions to be pruned. This behaviour helps to avoid pruning versions by mistake when first configuring this action.
+By default, both `prune-untagged` and `prune-tags-regexes` inputs are disabled and as result no versions will be matched for pruning. Either or both inputs must be explicitly configured for versions to be pruned. This behaviour helps to avoid pruning versions by mistake when first configuring this action.
 
 As this action is destructive, it's recommended to test any changes to the configuration of the action with a dry-run to ensure the expected versions are matched for pruning. For more details about dry-runs, see the [dry-run input](#dry-run).
 
-This is especially true when the [`tag-regex` input](#tag-regex) is used as the regular expression can easily match all versions of a container and result in complete deletion of all available versions.
+This is especially true when the [`prune-tags-regexes` input](#prune-tags-regexes) is used as regular expressions can easily match all versions of a container and result in complete deletion of all available versions.
 
 ## Quick start
 
@@ -20,9 +20,9 @@ steps:
       organization: your-org
       container: your-container
       dry-run: true # Dry-run first, then change to `false`
-      older-than: 7 # days
+      keep-younger-than: 7 # days
       keep-last: 2
-      untagged: true
+      prune-untagged: true
 ```
 
 ## Permissions
@@ -67,10 +67,6 @@ If neither are provided, then the packages of the authenticated user (cf. `token
 
 As this action is destructive, it's recommended to test any changes to the configuration of the action with a dry-run to ensure the expected versions are matched for pruning.
 
-### older-than
-
-**Optional** Minimum age in days of a version before it is pruned. Defaults to `0` which matches all versions of a container.
-
 ### keep-last
 
 **Optional** Count of most recent, matching containers to exclude from pruning. Defaults to `0` which means that all matching containers are pruned.
@@ -86,15 +82,22 @@ Matching is exact and case-sensitive.
 **Optional** List of regular expressions for tags to exclude from pruning, one per line.
 Each expression will be evaluated against all tags of a version. Any version with at least one tag matching the expression will be excluded from pruning.
 
-### untagged
+### keep-younger-than
+
+**Optional** Minimum age in days a version must have to qualify for pruning. All versions below that age at time of execution are excluded from pruning. Defaults to `0` which means no versions will be excluded from pruning.
+
+### prune-tags-regexes
+
+**Optional** List of regular expressions for tags to prune, one per line.
+Each expression will be evaluated against all tags of a version.
+Any version with at least one tag matching the expression will be pruned.
+Disabled by default (ie. no versions pruned based on tags).
+
+:warning: **Please note:** Extra care should be taken when using `prune-tags-regexes`, please make sure you've read the [Word of caution](#word-of-caution)
+
+### prune-untagged
 
 **Optional** Boolean controlling whether untagged versions should be pruned (`true`) or not (`false`). Defaults to `false`.
-
-### tag-regex
-
-**Optional** Regular expression which will be evaluated against all tags of a version. Any version with at least one tag matching the expression will be pruned. Disabled by defaults.
-
-:warning: **Please note:** Extra care should be taken when using `tag-regex`, please make sure you've read the [Word of caution](#word-of-caution)
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,7 @@ inputs:
     description: 'Minimum age in days of container versions to prune'
     required: false
     default: 0
+    deprecationMessage: Replaced by input `keep-younger-than`. This input will be removed in v2.0.0.
   keep-last:
     description: 'Count of most recent, matching containers to exclude from pruning'
     required: false
@@ -58,9 +59,11 @@ inputs:
     description: 'Whether untagged container versions should be pruned'
     required: false
     default: false
+    deprecationMessage: Replaced by input `prune-untagged`. This input will be removed in v2.0.0.
   tag-regex:
     description: 'Regular expression matching tagged container versions which should be pruned'
     required: false
+    deprecationMessage: Replaced by input `prune-tags-regexes`. This input will be removed in v2.0.0.
 output:
   count:
     description: 'Count of container versions that were pruned'

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,20 @@ inputs:
       Each expression will be evaluated against all tags of a version.
       Any version with at least one tag matching the expression will be excluded from pruning.
     required: false
+  keep-younger-than:
+    description: 'Minimum age in days of container versions that will be pruned'
+    required: false
+    default: 0
+  prune-tags-regexes:
+    description: |
+      List of regular expressions for tags to include in pruning, one per line.
+      Each expression will be evaluated against all tags of a version.
+      Any version with at least one tag matching the expression will be included in pruning.
+    required: false
+  prune-untagged:
+    description: 'Whether untagged container versions should be pruned'
+    required: false
+    default: false
   untagged:
     description: 'Whether untagged container versions should be pruned'
     required: false

--- a/index.js
+++ b/index.js
@@ -66,12 +66,16 @@ const run = async () => {
     const dryRun = asBoolean(core.getInput('dry-run'));
 
     const keepLast = Number(core.getInput('keep-last'));
+
+    // For backward compatibility of deprecated input `tag-regex`
+    const legacyTagRegex = core.getInput('tag-regex') ? [core.getInput('tag-regex')] : null;
+
     const filterOptions = {
-      olderThan: Number(core.getInput('older-than')),
-      untagged: asBoolean(core.getInput('untagged')),
-      tagRegex: core.getInput('tag-regex'),
       keepTags: core.getMultilineInput('keep-tags'),
       keepTagsRegexes: core.getMultilineInput('keep-tags-regexes'),
+      keepYoungerThan: Number(core.getInput('keep-younger-than')) || Number(core.getInput('older-than')),
+      pruneTagsRegexes: core.getInput('prune-tags-regexes') ? core.getMultilineInput('prune-tags-regexes') : legacyTagRegex,
+      pruneUntagged: asBoolean(core.getInput('prune-untagged')) || asBoolean(core.getInput('untagged')),
     };
 
     const octokit = github.getOctokit(token);

--- a/src/version-filter.js
+++ b/src/version-filter.js
@@ -7,22 +7,22 @@ const anyRegexMatch = (regexes) => (tags) =>
 
 const versionFilter = (options) => (version) => {
   const {
-    olderThan,
-    untagged,
-    tagRegex,
     keepTags,
     keepTagsRegexes,
+    keepYoungerThan,
+    pruneTagsRegexes,
+    pruneUntagged,
   } = options;
   const createdAt = new Date(version.created_at);
   const age = daysBetween(createdAt);
 
-  if (olderThan > age) {
+  if (keepYoungerThan > age) {
     return false;
   }
 
   const tags = version.metadata.container.tags;
 
-  if (untagged && (!tags || !tags.length)) {
+  if (pruneUntagged && (!tags || !tags.length)) {
     return true;
   }
 
@@ -34,7 +34,7 @@ const versionFilter = (options) => (version) => {
     return false;
   }
 
-  if (tagRegex && tags && tags.some((tag) => tag.match(tagRegex))) {
+  if (pruneTagsRegexes && tags && anyRegexMatch(pruneTagsRegexes)(tags)) {
     return true;
   }
 

--- a/src/version-filter.test.js
+++ b/src/version-filter.test.js
@@ -25,9 +25,9 @@ describe('versionFilter', () => {
     const version = Version(YEARS_AGO, ['tag1']);
 
     const prune = versionFilter({
-      olderThan: 0,
-      untagged: false,
-      tagRegex: undefined,
+      keepYoungerThan: 0,
+      pruneTagsRegexes: undefined,
+      pruneUntagged: false,
     })(version);
 
     expect(prune).toBe(false);
@@ -37,9 +37,9 @@ describe('versionFilter', () => {
     const version = Version(YEARS_AGO, []);
 
     const prune = versionFilter({
-      olderThan: 0,
-      untagged: true,
-      tagRegex: undefined,
+      keepYoungerThan: 0,
+      pruneTagsRegexes: undefined,
+      pruneUntagged: true,
     })(version);
 
     expect(prune).toBe(true);
@@ -49,9 +49,9 @@ describe('versionFilter', () => {
     const version = Version(YEARS_AGO, ['tag1']);
 
     const prune = versionFilter({
-      olderThan: 0,
-      untagged: true,
-      tagRegex: undefined,
+      keepYoungerThan: 0,
+      pruneTagsRegexes: undefined,
+      pruneUntagged: true,
     })(version);
 
     expect(prune).toBe(false);
@@ -61,9 +61,9 @@ describe('versionFilter', () => {
     const version = Version(TODAY, []);
 
     const prune = versionFilter({
-      olderThan: 3,
-      untagged: true,
-      tagRegex: undefined,
+      keepYoungerThan: 3,
+      pruneTagsRegexes: undefined,
+      pruneUntagged: true,
     })(version);
 
     expect(prune).toBe(false);
@@ -73,21 +73,43 @@ describe('versionFilter', () => {
     const version = Version(YEARS_AGO, ['tag-145', 'latest']);
 
     const prune = versionFilter({
-      olderThan: 0,
-      untagged: false,
-      tagRegex: '^tag-[0-9]{3}$',
+      keepYoungerThan: 0,
+      pruneTagsRegexes: ['^tag-[0-9]{3}$'],
+      pruneUntagged: false,
     })(version);
 
     expect(prune).toBe(true);
+  });
+
+  it('should prune all tagged versions with at least 1 tag matching any of the regexes', () => {
+    const versions = [
+      Version(YEARS_AGO, ['pr-123', 'pr-demo']),
+      Version(YEARS_AGO, ['pr-456', 'pr-alpha']),
+      Version(YEARS_AGO, ['pr-789', 'pr-beta']),
+    ]
+
+    const pruningFilter = versionFilter({
+      keepYoungerThan: 0,
+      pruneTagsRegexes: [
+        '^pr-123$',
+        'alpha$',
+      ],
+      pruneUntagged: false,
+    });
+
+    expect(versions.filter(pruningFilter)).toEqual([
+      Version(YEARS_AGO, ['pr-123', 'pr-demo']),
+      Version(YEARS_AGO, ['pr-456', 'pr-alpha']),
+    ]);
   });
 
   it('should NOT prune tagged version with no tag matching regex', () => {
     const version = Version(YEARS_AGO, ['tag-145x', 'latest']);
 
     const prune = versionFilter({
-      olderThan: 0,
-      untagged: false,
-      tagRegex: '^tag-[0-9]{3}$',
+      keepYoungerThan: 0,
+      pruneTagsRegexes: ['^tag-[0-9]{3}$'],
+      pruneUntagged: false,
     })(version);
 
     expect(prune).toBe(false);
@@ -97,9 +119,9 @@ describe('versionFilter', () => {
     const version = Version(TODAY, ['tag-145', 'latest']);
 
     const prune = versionFilter({
-      olderThan: 3,
-      untagged: false,
-      tagRegex: '^tag-[0-9]{3}$',
+      keepYoungerThan: 3,
+      pruneTagsRegexes: ['^tag-[0-9]{3}$'],
+      pruneUntagged: false,
     })(version);
 
     expect(prune).toBe(false);
@@ -112,9 +134,9 @@ describe('versionFilter', () => {
     ]
 
     const pruningFilter = versionFilter({
-      olderThan: 3,
-      untagged: true,
-      tagRegex: 'latest',
+      keepYoungerThan: 3,
+      pruneTagsRegexes: ['latest'],
+      pruneUntagged: true,
     });
 
     expect(versions.filter(pruningFilter)).toEqual(versions);
@@ -128,9 +150,9 @@ describe('versionFilter', () => {
     ]
 
     const pruningFilter = versionFilter({
-      olderThan: 0,
-      untagged: false,
-      tagRegex: '^pr-',
+      keepYoungerThan: 0,
+      pruneTagsRegexes: ['^pr-'],
+      pruneUntagged: false,
       keepTags: [
         'pr-demo',
         'pr-beta',
@@ -150,9 +172,9 @@ describe('versionFilter', () => {
     ]
 
     const pruningFilter = versionFilter({
-      olderThan: 0,
-      untagged: false,
-      tagRegex: '^pr-',
+      keepYoungerThan: 0,
+      pruneTagsRegexes: ['^pr-'],
+      pruneUntagged: false,
       keepTagsRegexes: [
         '^pr-d\\w+',
         '^pr-b\\w+',


### PR DESCRIPTION
Resolves #56
Resolves #10 

Inputs are only marked as deprecated and won't be removed until v2.0.0 to offer sufficient migration time.