### PR TITLE
Upgrade to NodeJS 20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup NodeJS 16
+      - name: Setup NodeJS
         uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '20'
           cache: 'npm'
 
       - name: Install deps

--- a/action.yml
+++ b/action.yml
@@ -68,5 +68,5 @@ output:
   count:
     description: 'Count of container versions that were pruned'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Resolves #77 

Node 16 deprecated in favour of Node 20: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/